### PR TITLE
Create an option to load lib and local app js files differently with …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,47 +1,53 @@
 var gulp = require('gulp');
 var sourcemaps = require('gulp-sourcemaps');
+const concat = require("gulp-concat");
+const uglify = require("gulp-uglify");
+// CSS
+var sass = require('gulp-sass')(require('sass'));
+var postcss = require('gulp-postcss');
+var autoprefixer = require('autoprefixer');
 
 // Compile & minify css
-function css () {
-	var sass = require('gulp-sass')(require('sass'));
-	var postcss = require('gulp-postcss');
-	var autoprefixer = require('autoprefixer');
-
-	return gulp.src('./protected/scss/app.scss')
-			.pipe(sourcemaps.init())
-			.pipe(sass({outputStyle: 'compressed'}))
-			.pipe(postcss([autoprefixer()]))
-			.pipe(sourcemaps.write('.'))
-			.pipe(gulp.dest('./assets/css'));
-};
+function css() {
+    return gulp.src('./protected/scss/app.scss')
+        .pipe(sourcemaps.init())
+        .pipe(sass({outputStyle: 'compressed'}))
+        .pipe(postcss([autoprefixer()]))
+        .pipe(sourcemaps.write('.'))
+        .pipe(gulp.dest('./assets/css'));
+}
 
 // Compile & minify js
-function js () {
-	var concat = require('gulp-concat');
-	var uglify = require('gulp-uglify');
-	return gulp.src([
-		'./node_modules/jquery/dist/jquery.min.js',
-		'./node_modules/bootstrap/dist/js/bootstrap.bundle.min.js',
-		'./node_modules/@fortawesome/fontawesome-free/js/all.min.js',
-		'./node_modules/smoothscroll-polyfill/dist/smoothscroll.min.js',
-		'./node_modules/autosize/dist/autosize.min.js',
-		'./protected/js/**/*.js'
-	]).pipe(concat('app.js')).pipe(sourcemaps.init()).pipe(uglify()).pipe(sourcemaps.write('.')).pipe(gulp.dest('./assets/js'))
-};
+function jsLib() {
+    return gulp.src([
+        './node_modules/jquery/dist/jquery.min.js',
+        './node_modules/bootstrap/dist/js/bootstrap.bundle.min.js',
+        './node_modules/@fortawesome/fontawesome-free/js/all.min.js',
+        './node_modules/smoothscroll-polyfill/dist/smoothscroll.min.js',
+        './node_modules/autosize/dist/autosize.min.js',
+    ]).pipe(concat('lib.js')).pipe(sourcemaps.init()).pipe(uglify()).pipe(sourcemaps.write('.')).pipe(gulp.dest('./assets/js'));
+}
+
+function jsApp() {
+    return gulp.src(
+        './protected/js/**/*.js'
+    ).pipe(concat('app.js')).pipe(sourcemaps.init()).pipe(uglify()).pipe(sourcemaps.write('.')).pipe(gulp.dest('./assets/js'));
+}
 
 // Watch
-function watch () {
-	// Watch scss files
-	gulp.watch('protected/scss/**/*.scss', css);
+function watch() {
+    // Watch scss files
+    gulp.watch('protected/scss/**/*.scss', css);
 
-	// Watch js file
-	gulp.watch('protected/js/**/*.js', js);
-};
+    // Watch js file
+    gulp.watch('protected/js/**/*.js', jsApp);
+}
 
 // Public task
-exports.css   = css;
-exports.js    = js;
+exports.css = css;
+exports.jsLib = jsLib;
+exports.jsApp = jsApp;
 exports.watch = watch;
 
 // Default Task
-exports.default = gulp.series(css, js, watch);
+exports.default = gulp.series(css, jsLib, jsApp, watch);

--- a/protected/src/Application/Page.php
+++ b/protected/src/Application/Page.php
@@ -26,6 +26,8 @@ class Page extends \Sy\Bootstrap\Application\Page {
 		// Application css
 		$this->addCssLink(WEB_ROOT . '/assets/css/app.css');
 
+		// Library js
+		$this->addJsLink(WEB_ROOT . '/assets/js/lib.js');
 		// Application js
 		$this->addJsLink(WEB_ROOT . '/assets/js/app.js');
 	}


### PR DESCRIPTION
Problem: when watching js file changes in `protected/js/`, lib from node_modules and local js file are concat to create app.js in `assets/js`, therefore it takes a long time and can be resolved.

Solution: 

- Create a task to uglify and concat all lib from node_modules, not link with local js files.
- Another task to operate on local files

=> Watch will no longer occur on node_modules files